### PR TITLE
Split columns shortkey "T"

### DIFF
--- a/content_scripts/commands.js
+++ b/content_scripts/commands.js
@@ -629,6 +629,11 @@ const Commands = {
             name: "Open tabs list",
             group: "ui",
         },
+        splitTextToColumns: {
+            fn: SheetActions.splitTextToColumns.bind(SheetActions),
+            name: "Split text to columns",
+            group: "editing",
+        },
 
         // /////////////////////////////////////////
     },
@@ -743,6 +748,7 @@ const Commands = {
             openCommandPalette: ":",
             openSearch: "slash",
             openTabsList: "P",
+            splitTextToColumns: "T",
 
             // Editing
             editCell: "i",

--- a/content_scripts/sheet_actions.js
+++ b/content_scripts/sheet_actions.js
@@ -33,6 +33,7 @@ const SheetActions = {
         rowAbove: { parent: "Insert", caption: /^Insert \d+ row above/ },
         rowBelow: { parent: "Insert", caption: /^Insert \d+ row below/ },
         rows: { parent: "Insert", caption: "Rows►" },
+        splitTextToColumns: { parent: "Data", caption: "Split text to columns" },
         undo: { parent: "Edit", caption: "Undo" },
         unmerge: { parent: "Format", caption: "Unmerge" },
         zoom: { parent: "View", caption: "Zoom►" },
@@ -1240,6 +1241,17 @@ const SheetActions = {
             ".docs-butterbar-dismiss"
         );
         for (let button of dismissButtons) KeyboardUtils.simulateClick(button);
+    },
+
+    splitTextToColumns() {
+        this.clickMenu(this.menuItems.splitTextToColumns);
+        // After split operation, call editCell to refocus, then escape
+        setTimeout(() => {
+            this.editCell();
+            setTimeout(() => {
+                this.typeKeyFn(KeyboardUtils.keyCodes.esc);
+            }, 100);
+        }, 500);
     },
 
     // Opens a new tab for each link in the current cell.

--- a/content_scripts/sheet_actions.js
+++ b/content_scripts/sheet_actions.js
@@ -1245,13 +1245,9 @@ const SheetActions = {
 
     splitTextToColumns() {
         this.clickMenu(this.menuItems.splitTextToColumns);
-        // After split operation, call editCell to refocus, then escape
-        setTimeout(() => {
-            this.editCell();
-            setTimeout(() => {
-                this.typeKeyFn(KeyboardUtils.keyCodes.esc);
-            }, 100);
-        }, 500);
+        // Immediately refocus by entering and exiting edit mode
+        this.editCell();
+        this.typeKeyFn(KeyboardUtils.keyCodes.esc);
     },
 
     // Opens a new tab for each link in the current cell.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Sheetkeys (Rishi)",
-  "version": "0.1",
+  "version": "1.0.2",
   "description": "TODO",
   "permissions": [
     "storage"


### PR DESCRIPTION
## Summary
- Added keyboard shortcut `T` to trigger Data → "Split text to columns" in Google Sheets
- Implemented automatic refocus after the split operation completes

## Test plan
- [ ] Press `T` on a cell containing text to split
- [ ] Verify the "Split text to columns" dialog appears
- [ ] Complete the split operation
- [ ] Verify the sheet is properly refocused and you can continue using keyboard navigation

🤖 Generated with [Claude Code](https://claude.ai/code)